### PR TITLE
bug fix for rect type error when dumping iOS hierarchy

### DIFF
--- a/weditor/web/uidumplib.py
+++ b/weditor/web/uidumplib.py
@@ -145,7 +145,7 @@ def get_ios_hierarchy(d, scale):
             rect = node['rect']
             nrect = {}
             for k, v in rect.items():
-                nrect[k] = v * scale
+                nrect[k] = v * scale if isinstance(v, int) else "null"
             node['rect'] = nrect
 
         for child in node.get('children', []):


### PR DESCRIPTION
![image](https://github.com/alibaba/web-editor/assets/65639657/3e3fa1b3-e485-4e35-9387-ef0f034747ec)
value of rect error when geting large page source