### PR TITLE
feat: load hierarchy from saved file

### DIFF
--- a/weditor/static/js/common.js
+++ b/weditor/static/js/common.js
@@ -1,9 +1,9 @@
-// Copies a string to the clipboard. Must be called from within an 
+// Copies a string to the clipboard. Must be called from within an
 // event handler such as click. May return false if it failed, but
-// this is not always possible. Browser support for Chrome 43+, 
+// this is not always possible. Browser support for Chrome 43+,
 // Firefox 42+, Safari 10+, Edge and IE 10+.
 // IE: The clipboard feature may be disabled by an administrator. By
-// default a prompt is shown the first time the clipboard is 
+// default a prompt is shown the first time the clipboard is
 // used (per session).
 function copyToClipboard(text) {
   if (window.clipboardData && window.clipboardData.setData) {
@@ -72,4 +72,41 @@ function b64toBlob(b64Data, contentType, sliceSize) {
   return new Blob(byteArrays, {
     type: contentType
   });
+}
+
+var dumplib = {
+  parseIosJson: function(json, screenshotWidth) {
+    var node = JSON.parse(json);
+    // get 414, 736 from {{0, 0}, {414, 736}}
+    var windowSize = /\{\{(.+)\}, \{(.+)\}\}/.exec(node.frame)[2].split(',').map(v => parseInt(v, 10))
+    var scale = screenshotWidth ? screenshotWidth / windowSize[0] : 1
+
+    function travel(node) {
+      node['_id'] = node['_id'] || uuidv4();
+      node['_type'] = node['type'] || null;
+      if (node['rect']) {
+        let rect = node['rect'];
+        let nrect = {};
+        for (let k in rect) {
+          nrect[k] = rect[k] * scale;
+        }
+        node['rect'] = nrect;
+      }
+
+      if (node['children']) {
+        node['children'].forEach(child => {
+          travel(child);
+        });
+      }
+      return node;
+    }
+
+    return {
+      jsonHierarchy: travel(node),
+      windowSize
+    }
+  },
+  parseAndroidJson: function(json) {
+
+  }
 }

--- a/weditor/templates/index.html
+++ b/weditor/templates/index.html
@@ -62,6 +62,12 @@
             <el-switch v-model="liveScreen" active-text="实时" inactive-text="静态">
             </el-switch>
           </template>
+          <input type="file" id="load_hierarchy" name="load_hierarchy" accept="*" @change="(e) => {loadHierarchy(e.target.files)}" multiple style="display: none;"/>
+          <el-tooltip :open-delay="500" content="Load screenshot (or/and) source json" placement="bottom">
+            <label class="btn btn-default" for="load_hierarchy" v-if="platform == 'iOS'">
+              <i class="fa fa-upload" :class='{"fa-spin": dumping}'></i> Load Hierarchy
+            </label>
+          </el-tooltip>
         </form>
         <ul class="nav navbar-nav navbar-right">
           <!-- <li><a href="#">Link</a></li> -->
@@ -292,6 +298,7 @@
   </div>
 </body>
 
+<script src="https://cdn.jsdelivr.net/npm/uuid@8.3.2/dist/umd/uuidv4.min.js"></script>
 <script src="/cdn.jsdelivr.net/npm/jquery@3.3.1/dist/jquery.min.js"></script>
 <script src="/cdn.jsdelivr.net/bootstrap/3.3.7/js/bootstrap.min.js"></script>
 <script src="/cdn.jsdelivr.net/bootstrap.select/1.12.2/js/bootstrap-select.min.js"></script>


### PR DESCRIPTION
添加一个“Load Hierarchy”功能，可以从自己保存的screenshot和source中加载hierarchy ，方便离线定位问题

## 说明
+ 目前只做了IOS，对source tree的处理移植了python后端的代码。
+ 想把这个功能做成纯前端，有些纠结，所以暂时也没做Andriod的